### PR TITLE
fix(ui): adjust layout and styling in status bar and product selection

### DIFF
--- a/apps/pos/src/app/ui/components/pos/status-bar/status-bar.component.ts
+++ b/apps/pos/src/app/ui/components/pos/status-bar/status-bar.component.ts
@@ -11,13 +11,13 @@ import { ButtonComponent } from '../../shared/button/button.component';
       Desktop: flush to bottom, offset by the w-64 sidebar
     -->
     <div
-      class="fixed bottom-[calc(56px+env(safe-area-inset-bottom))] lg:bottom-0 left-0 lg:left-64 right-0 z-40 px-3 lg:px-6 pb-3 lg:pb-6 pointer-events-none transition-all duration-300"
+      class="fixed bottom-[calc(56px+env(safe-area-inset-bottom))] lg:bottom-0 left-0 lg:left-64 right-0 z-40 px-3 lg:px-6 pb-2 md:pb-3 lg:pb-8 pointer-events-none transition-all duration-300"
     >
-      <div class="max-w-4xl mx-auto pointer-events-auto">
+      <div class="max-w-6xl mx-auto pointer-events-auto">
         <div
-          class="glass-card bg-surface-900/90! backdrop-blur-2xl! border-white/10 p-3 sm:p-4 shadow-2xl flex items-center justify-between gap-3 sm:gap-6 translate-y-0 animate-slide-up"
+          class="glass-card bg-surface-900/90! backdrop-blur-2xl! border-white/10 p-2 md:p-4 shadow-2xl flex items-center justify-between gap-3 md:gap-6 translate-y-0 animate-slide-up"
         >
-          <div class="flex items-center gap-2 sm:gap-4 min-w-0">
+          <div class="flex items-center gap-2 md:gap-4">
             <div
               class="w-9 h-9 sm:w-12 sm:h-12 rounded-xl sm:rounded-2xl primary-gradient flex items-center justify-center text-white relative shrink-0"
             >
@@ -60,7 +60,7 @@ import { ButtonComponent } from '../../shared/button/button.component';
             [isDisabled]="itemCount === 0 && !canBeEmpty"
             [label]="buttonLabel"
             [hasRightIcon]="true"
-            class="scale-90 sm:scale-100 origin-right shrink-0"
+            size="lg"
           >
             <svg
               rightIcon
@@ -82,13 +82,6 @@ import { ButtonComponent } from '../../shared/button/button.component';
       </div>
     </div>
   `,
-  styles: [
-    `
-      :host {
-        display: block;
-      }
-    `,
-  ],
 })
 export class StatusBarComponent {
   @Input() itemCount = 0;

--- a/apps/pos/src/app/ui/pages/pos/product-selection.component.html
+++ b/apps/pos/src/app/ui/pages/pos/product-selection.component.html
@@ -10,7 +10,7 @@
 </div>
 
 <!-- Products Grid Area -->
-<div class="animate-fade-in pb-28 md:pb-32-">
+<div class="animate-fade-in pb-28 md:pb-32">
   <div class="max-w-7xl mx-auto py-2">
     <!-- Products Grid -->
     <div class="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-8">
@@ -59,7 +59,7 @@
         <div class="flex flex-col lg:flex-1 gap-2">
           <h2
             id="product-modal-title"
-            class="max-h-22 overflow-x-auto text-3xl font-black text-surface-900"
+            class="max-h-[5.5rem] overflow-x-auto text-3xl font-black text-surface-900"
           >
             {{ selectedProduct()?.name }}
           </h2>
@@ -91,7 +91,7 @@
         </div>
       </div>
 
-      <div class="flex flex-col gap-10 p-6 overflow-y-auto">
+      <div class="flex flex-col gap-10 p-6 overflow-y-auto grow min-h-0">
         <!-- Variants Selection -->
         @if (productVariants().length > 0) {
           <div>

--- a/apps/pos/src/app/ui/pages/pos/product-selection.component.html
+++ b/apps/pos/src/app/ui/pages/pos/product-selection.component.html
@@ -10,10 +10,10 @@
 </div>
 
 <!-- Products Grid Area -->
-<div class="animate-fade-in pb-32 mt-4">
+<div class="animate-fade-in pb-28 md:pb-32-">
   <div class="max-w-7xl mx-auto py-2">
     <!-- Products Grid -->
-    <div class="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-8">
+    <div class="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-8">
       @for (product of filteredProducts(); track product.id) {
         <app-product-card
           [product]="product"
@@ -36,7 +36,7 @@
 <app-status-bar
   [itemCount]="totalItemCount()"
   [subtotal]="displaySubtotal()"
-  [buttonLabel]="existingOrder() ? 'Manage Order' : 'View Cart'"
+  buttonLabel="View Cart"
   [canBeEmpty]="!!existingOrder()"
   (action)="viewCart()"
 ></app-status-bar>
@@ -51,50 +51,50 @@
     aria-labelledby="product-modal-title"
   >
     <div
-      class="bg-white rounded-3xl shadow-2xl max-w-lg w-full max-h-[calc(100dvh-1.5rem)] sm:max-h-[90vh] overflow-hidden flex flex-col animate-slide-up"
+      class="bg-white rounded-3xl shadow-2xl max-w-lg w-full max-h-[calc(100dvh-8rem)] sm:max-h-[90vh] overflow-hidden flex flex-col animate-slide-up"
       (click)="$event.stopPropagation()"
     >
       <!-- Modal Header -->
-      <div class="relative h-36 sm:h-64 overflow-hidden shrink-0">
-        <div class="absolute inset-0 primary-gradient opacity-20"></div>
-        <div class="absolute inset-0 flex items-center justify-center text-8xl" aria-hidden="true">
-          🍽️
-        </div>
-        <button
-          type="button"
-          (click)="closeModal()"
-          class="absolute top-4 right-4 w-10 h-10 rounded-full bg-white/30 border border-white/40 backdrop-blur-md text-surface-800 flex items-center justify-center text-2xl shadow-sm hover:bg-white/70 transition-colors"
-          aria-label="Close product details"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            class="w-5 h-5"
-            aria-hidden="true"
+      <div class="flex items-start justify-between p-6 py-4 bg-primary-600/20 gap-2">
+        <div class="flex flex-col lg:flex-1 gap-2">
+          <h2
+            id="product-modal-title"
+            class="max-h-22 overflow-x-auto text-3xl font-black text-surface-900"
           >
-            <path d="M18 6 6 18M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
-
-      <div class="p-5 sm:p-8 overflow-y-auto grow min-h-0">
-        <div class="mb-8">
-          <h2 id="product-modal-title" class="text-3xl font-black text-surface-900 mb-1">
             {{ selectedProduct()?.name }}
           </h2>
           <p class="text-primary-600 font-bold text-xl">
             Base Price: €{{ (selectedProduct()?.price ?? 0).toFixed(2) }}
           </p>
         </div>
+        <div>
+          <button
+            type="button"
+            (click)="closeModal()"
+            class="flex w-10 h-10 rounded-full bg-white/30 border border-white/40 backdrop-blur-md text-surface-800 items-center justify-center text-2xl shadow-sm hover:bg-white/70 transition-colors"
+            aria-label="Close product details"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="w-5 h-5"
+              aria-hidden="true"
+            >
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
 
+      <div class="flex flex-col gap-10 p-6 overflow-y-auto">
         <!-- Variants Selection -->
         @if (productVariants().length > 0) {
-          <div class="mb-8">
+          <div>
             <label class="block text-xs font-black text-surface-400 uppercase tracking-widest mb-4"
               >Choose Variant</label
             >
@@ -123,7 +123,7 @@
 
         <!-- Extras Selection -->
         @if (productExtras().length > 0) {
-          <div class="mb-8">
+          <div>
             <label class="block text-xs font-black text-surface-400 uppercase tracking-widest mb-4"
               >Add Extras</label
             >
@@ -147,7 +147,7 @@
         }
 
         <!-- Quantity & Notes -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label class="block text-xs font-black text-surface-400 uppercase tracking-widest mb-4"
               >Quantity</label
@@ -177,8 +177,8 @@
       </div>
 
       <!-- Fixed Footer -->
-      <div class="px-5 sm:px-8 pt-4 pb-5 sm:pb-8 border-t border-surface-100 bg-white shrink-0">
-        <div class="flex items-end justify-between gap-4">
+      <div class="p-6 py-4 border-t border-slate-200 bg-white shrink-0">
+        <div class="flex items-center justify-between gap-4">
           <div>
             <div class="text-surface-400 text-[10px] font-black uppercase tracking-widest">
               Total Price
@@ -187,7 +187,7 @@
               €{{ (calculatedUnitPrice() * quantity()).toFixed(2) }}
             </div>
           </div>
-          <app-button (click)="addToCart()" label="Add to Order"></app-button>
+          <app-button (click)="addToCart()" label="Add to Order" size="lg"></app-button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request focuses on improving the UI consistency and layout for the POS product selection and status bar components. The main changes update spacing, sizing, and visual structure to create a more polished and responsive interface, especially across different screen sizes.

UI consistency and layout improvements:

* Adjusted padding, gaps, and maximum widths in the `status-bar.component.ts` to ensure better alignment and spacing across breakpoints, and increased the maximum container width for desktop layouts.
* Updated the button in the status bar to use the `size="lg"` property instead of a custom scale class for more consistent sizing.
* Removed unused custom styles from the `StatusBarComponent` for cleaner code.

Product modal enhancements:

* Refactored the product modal header to display product name and price more prominently, moved the close button, and consolidated header content for improved clarity and accessibility. Also updated modal padding and spacing for a cleaner look. [[1]](diffhunk://#diff-7c0e28b96b2ba4de943c17e2d1e260814759dad4a77acc27eed4e966e95b5085L54-R74) [[2]](diffhunk://#diff-7c0e28b96b2ba4de943c17e2d1e260814759dad4a77acc27eed4e966e95b5085L84-R97)
* Updated modal footer and action button to use consistent padding, border color, and button size, improving visual balance and touch targets. [[1]](diffhunk://#diff-7c0e28b96b2ba4de943c17e2d1e260814759dad4a77acc27eed4e966e95b5085L180-R181) [[2]](diffhunk://#diff-7c0e28b96b2ba4de943c17e2d1e260814759dad4a77acc27eed4e966e95b5085L190-R190)

Grid and cart updates:

* Reduced product grid gaps for better density on smaller screens and adjusted padding in the product selection area.
* Changed the cart button label logic to always show "View Cart" for clarity and consistency.